### PR TITLE
initial support for changing registry url of APBs

### DIFF
--- a/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/roles/ansible-service-broker-setup/defaults/main.yml
@@ -10,3 +10,6 @@ broker_mobile_configuration:
 - section: broker
   name: launch_apb_on_bind
   value: true
+
+#The url for the registry that hosts our APB images
+ansible_playbookbundle_registry_url: https://registry.hub.docker.com

--- a/roles/ansible-service-broker-setup/templates/aerogearcatalog_registry.yaml.j2
+++ b/roles/ansible-service-broker-setup/templates/aerogearcatalog_registry.yaml.j2
@@ -1,37 +1,36 @@
 ---
 
 registry:
-  - type: dockerhub
+  - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-mdc
-    url: https://registry.hub.docker.com
+    url: "{{ ansible_playbookbundle_registry_url }}"
     org: aerogearcatalog
     tag: "{{ mobile_developer_console_apb|default('latest') }}"
     white_list:
       - '.*mobile-developer-console-apb$'
-  - type: dockerhub
+  - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-push
-    url: https://registry.hub.docker.com
+    url: "{{ ansible_playbookbundle_registry_url }}"
     org: aerogearcatalog
     tag: "{{ unifiedpush_apb|default('latest') }}"
     white_list:
       - '.*unifiedpush-apb$'
-  - type: dockerhub
+  - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-keycloak
-    url: https://registry.hub.docker.com
+    url: "{{ ansible_playbookbundle_registry_url }}"
     org: aerogearcatalog
     tag: "{{ keycloak_apb|default('latest') }}"
     white_list:
-      - '.*keycloak-apb$'
-  - type: dockerhub
+  - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-metrics
-    url: https://registry.hub.docker.com
+    url: "{{ ansible_playbookbundle_registry_url }}"
     org: aerogearcatalog
     tag: "{{ metrics_apb|default('latest') }}"
     white_list:
       - '.*metrics-apb$'
-  - type: dockerhub
+  - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-sync
-    url: https://registry.hub.docker.com
+    url: "{{ ansible_playbookbundle_registry_url }}"
     org: aerogearcatalog
     tag: "{{ sync_app_apb|default('latest') }}"
     white_list:


### PR DESCRIPTION
to test with a standalone registry the following command can be used:

```
ansible-playbook install-mobile-services.yml \
-e ansible_playbookbundle_registry_url=http://registry.example.com:5000 \
-e ansible_playbookbundle_registry_type=apiv2
```

