### PR TITLE
fix: whitelist keycloak-apb

### DIFF
--- a/roles/ansible-service-broker-setup/templates/aerogearcatalog_registry.yaml.j2
+++ b/roles/ansible-service-broker-setup/templates/aerogearcatalog_registry.yaml.j2
@@ -21,6 +21,7 @@ registry:
     org: aerogearcatalog
     tag: "{{ keycloak_apb|default('latest') }}"
     white_list:
+      - '.*keycloak-apb$'
   - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-metrics
     url: "{{ ansible_playbookbundle_registry_url }}"


### PR DESCRIPTION
Seems this was accidentally removed with last PR. Now keycloak is not available in catalog. Putting it back.