### PR TITLE
fix: put apb registry org in a variable

### DIFF
--- a/roles/ansible-service-broker-setup/defaults/main.yml
+++ b/roles/ansible-service-broker-setup/defaults/main.yml
@@ -13,3 +13,6 @@ broker_mobile_configuration:
 
 #The url for the registry that hosts our APB images
 ansible_playbookbundle_registry_url: https://registry.hub.docker.com
+
+#The organisation that our APB images are in
+ansible_playbook_bundle_registry_org: aerogearcatalog

--- a/roles/ansible-service-broker-setup/templates/aerogearcatalog_registry.yaml.j2
+++ b/roles/ansible-service-broker-setup/templates/aerogearcatalog_registry.yaml.j2
@@ -4,35 +4,35 @@ registry:
   - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-mdc
     url: "{{ ansible_playbookbundle_registry_url }}"
-    org: aerogearcatalog
+    org: "{{ ansible_playbook_bundle_registry_org }}"
     tag: "{{ mobile_developer_console_apb|default('latest') }}"
     white_list:
       - '.*mobile-developer-console-apb$'
   - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-push
     url: "{{ ansible_playbookbundle_registry_url }}"
-    org: aerogearcatalog
+    org: "{{ ansible_playbook_bundle_registry_org }}"
     tag: "{{ unifiedpush_apb|default('latest') }}"
     white_list:
       - '.*unifiedpush-apb$'
   - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-keycloak
     url: "{{ ansible_playbookbundle_registry_url }}"
-    org: aerogearcatalog
+    org: "{{ ansible_playbook_bundle_registry_org }}"
     tag: "{{ keycloak_apb|default('latest') }}"
     white_list:
       - '.*keycloak-apb$'
   - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-metrics
     url: "{{ ansible_playbookbundle_registry_url }}"
-    org: aerogearcatalog
+    org: "{{ ansible_playbook_bundle_registry_org }}"
     tag: "{{ metrics_apb|default('latest') }}"
     white_list:
       - '.*metrics-apb$'
   - type: "{{ ansible_playbookbundle_registry_type | default('dockerhub') }}"
     name: ag-sync
     url: "{{ ansible_playbookbundle_registry_url }}"
-    org: aerogearcatalog
+    org: "{{ ansible_playbook_bundle_registry_org }}"
     tag: "{{ sync_app_apb|default('latest') }}"
     white_list:
       - '.*sync-app-apb$'


### PR DESCRIPTION
This is a low priority PR so feel free to hold off on reviewing this until next week.

Just a super minor improvement I figure we will need to make at some stage. The reason I did this is because I was following this doc: https://github.com/aerogear/mobile-services-installer/blob/master/apb-release.md

and when I got to step 3:

> Verify the APB by building an image and deploy it somewhere. If apb push works for you, you should be easily verify it locally. Otherwise you may need to build an image with the docker file, and push it to a remote registry. Then change the registry in aerogearcatalog_registry.yaml.j2, and ran the installer.