### PR TITLE
fix: simplify broker refresh instructions with a script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.retry
+scripts/broker.json

--- a/apb-release.md
+++ b/apb-release.md
@@ -9,11 +9,16 @@ Here are the steps to release an APB:
     ````
 3. Verify the APB by building an image and deploy it somewhere. If `apb build` and `apb push` works for you, you should be easily verify it locally. Otherwise you may need to build an image with the docker file, and push it to a remote registry. Then change the registry in [aerogearcatalog_registry.yaml.j2](./roles/ansible-service-broker-setup/templates/aerogearcatalog_registry.yaml.j2), and ran the installer. To force the service catalog to be refreshed, ran the following command:
     ```
-    oc get clusterservicebroker ansible-service-broker -o=json > broker.json
-    oc delete clusterservicebroker ansible-service-broker
-    oc create -f broker.json
+    ./scripts/refresh-broker.sh
     ```
-    Then you should be able to run the APB from the service catalog.
+    Then you should be able to run the APB from the service catalog. If you see the following error:
+    ```
+    Error from server (NotFound): clusterservicebrokers.servicecatalog.k8s.io "openshift-automation-service-broker" not found
+    ```
+    It's most likely you are using an older version of OpenShift where the broker is still called `ansible-service-broker`. You can run the following command.
+    ```
+    broker=ansible-service-broker ./scripts/refresh-broker.sh
+    ```
 4. Once the changes is verified yourself, create a new PR to get it reviewed.
 5. Once the PR is merged to master, create a new tag for the repo. It should follow the semver convention to bump the version.
 6. Once the tag is created, there should be a docker build triggered for the apb. Wait until the tag is showing up in dockerhub.

--- a/scripts/refresh-broker.sh
+++ b/scripts/refresh-broker.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+defaultbroker="openshift-automation-service-broker"
+
+broker=${broker:-$defaultbroker}
+
+echo "refreshing broker $broker"
+
+oc get clusterservicebroker $broker -o=json > broker.json
+oc delete clusterservicebroker $broker
+oc create -f broker.json
+rm broker.json


### PR DESCRIPTION
The title says it all. Makes things a little bit quicker when testing APBs, etc.