### PR TITLE
add a new role for setting up demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ It also contains scripts for local development of Mobile Services (using `Minish
 
 6. Verify that installation was successful by navigating to https://your-openshift-instance-url.com/console/catalog. A new tab `Mobile` should appear in the catalog.
 
+## Setup services for demo
+
+If you want to also setup all the required services for a demo, you can run this playbook:
+
+```
+ansible-playbook setup-demo.yml
+```
+
+This playbook will:
+
+* Provision all the mobile services into a namespace, including showcase server.
+* Create a mobile client for the showcase app.
+* Bind all the available services to the showcase app (if no push information is provided, then push service won't be bound)
+* Make sure the showcase server app is protected by the IDM service, and supports file upload.
+* Setup the following users in the IDM service
+  * User 1:
+    * username: admin
+    * password: admin
+    * realm role: admin
+    * client role for the showcase app: admin
+  * User 2:
+    * username: developer
+    * password: developer
+    * realm role: developer
+    * client role for the showcase app: developer
+
+You can then login to the Mobile Developer Console and copy the configuration for the showcase app, and paste it into the `mobile-services.json` file for the showcase client app.
+
 ## Local development
 
 By following next steps, you can spin up your local OpenShift instance with Mobile Services already installed.

--- a/roles/setup-services/defaults/main.yml
+++ b/roles/setup-services/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+namespace: mobile
+appname: showcase
+push_android_sender_id: ""
+push_android_server_key: ""
+push_ios_cert_content: ""
+push_ios_cert_passphase: ""
+push_ios_cert_production: ""
+services:
+  - db
+  - idm
+  - mdc
+  - metrics
+  - push
+  - datasync
+showcase_server_file_storage_size: 100Mi

--- a/roles/setup-services/tasks/configure-keycloak.yml
+++ b/roles/setup-services/tasks/configure-keycloak.yml
@@ -1,0 +1,212 @@
+---
+
+- name: Get keycloak route
+  shell: oc get route keycloak-route -o jsonpath={.spec.host}
+  register: keycloak_route_output
+
+- name: Get id for client showcase-public
+  shell: oc get secret keycloak-secret-showcase-public -o jsonpath={.data.id} | base64 --decode
+  register: public_client_id_output
+
+- set_fact:
+    PUBLIC_CLIENT_ID: "{{ public_client_id_output.stdout }}"
+
+- name: Generate keycloak auth token for admin user
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/realms/master/protocol/openid-connect/token"
+    method: POST
+    body: "client_id=admin-cli&username=admin&password=admin&grant_type=password"
+    validate_certs: no
+  register: keycloak_auth_response
+  retries: 20
+  delay: 2
+  until: keycloak_auth_response.status == 503 or
+         keycloak_auth_response.status in [200, 401, 403]
+  ignore_errors: yes
+
+- name: Create new realm roles
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/roles"
+    method: POST
+    body: "{\"name\": \"{{ item }}\", \"clientRole\": false }"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [201, 409]
+  with_items:
+    - admin
+    - developer
+  ignore_errors: yes
+
+- name: Create new client roles
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/clients/{{PUBLIC_CLIENT_ID}}/roles"
+    method: POST
+    body: "{\"name\": \"{{ item }}\", \"clientRole\": true }"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [201, 409]
+  with_items:
+    - admin
+    - developer
+  ignore_errors: yes
+
+- name: Create admin user
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users"
+    method: POST
+    body: "{\"username\": \"admin\", \"enabled\": true, \"credentials\":[{\"type\":\"password\", \"value\": \"admin\", \"temporary\": false}]}"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [201, 409]
+  ignore_errors: yes
+
+- name: Get admin user id
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users?briefRepresentation=true&username=admin"
+    method: GET
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200]
+    return_content: yes
+  register: admin_user_info
+  ignore_errors: yes
+
+- set_fact:
+    ADMIN_USER_ID:  "{{ admin_user_info.json[0].id }}"
+
+- name: Get admin realm role info
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/roles/admin"
+    method: GET
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200]
+    return_content: yes
+  register: admin_role_info
+  ignore_errors: yes
+
+- name: Get admin client role info
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/clients/{{PUBLIC_CLIENT_ID}}/roles/admin"
+    method: GET
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200]
+    return_content: yes
+  register: admin_client_role_info
+  ignore_errors: yes
+
+- name: Assign realm role to admin user
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users/{{ADMIN_USER_ID}}/role-mappings/realm"
+    method: POST
+    body: "[{{ admin_role_info.json }}]"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200, 204]
+  ignore_errors: yes
+
+- name: Assign client role to admin user
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users/{{ADMIN_USER_ID}}/role-mappings/clients/{{PUBLIC_CLIENT_ID}}"
+    method: POST
+    body: "[{{ admin_client_role_info.json }}]"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200, 204]
+  ignore_errors: yes
+
+- name: Create developer user
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users"
+    method: POST
+    body: "{\"username\": \"developer\", \"enabled\": true, \"credentials\":[{\"type\":\"password\", \"value\": \"developer\", \"temporary\": false}]}"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [201, 409]
+  ignore_errors: yes
+
+- name: Get developer user id
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users?briefRepresentation=true&username=developer"
+    method: GET
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200]
+    return_content: yes
+  register: developer_user_info
+  ignore_errors: yes
+
+- set_fact:
+    DEVELOPER_USER_ID:  "{{ developer_user_info.json[0].id }}" 
+
+- name: Get developer realm role info
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/roles/developer"
+    method: GET
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200]
+    return_content: yes
+  register: developer_role_info
+  ignore_errors: yes
+
+- name: Get developer client role info
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/clients/{{PUBLIC_CLIENT_ID}}/roles/developer"
+    method: GET
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200]
+    return_content: yes
+  register: developer_client_role_info
+  ignore_errors: yes
+
+- name: Assign realm role to developer user
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users/{{DEVELOPER_USER_ID}}/role-mappings/realm"
+    method: POST
+    body: "[{{ developer_role_info.json }}]"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200, 204]
+  ignore_errors: yes
+
+- name: Assign client role to developer user
+  uri:
+    url: "https://{{ keycloak_route_output.stdout }}/auth/admin/realms/{{namespace}}/users/{{DEVELOPER_USER_ID}}/role-mappings/clients/{{PUBLIC_CLIENT_ID}}"
+    method: POST
+    body: "[{{ developer_client_role_info.json }}]"
+    validate_certs: no
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ keycloak_auth_response.json.access_token }}"
+    status_code: [200, 204]
+  ignore_errors: yes
+

--- a/roles/setup-services/tasks/configure-keycloak.yml
+++ b/roles/setup-services/tasks/configure-keycloak.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Get keycloak route
-  shell: oc get route keycloak-route -o jsonpath={.spec.host}
+  shell: oc get route keycloak-route -o jsonpath={.spec.host} -n {{namespace}}
   register: keycloak_route_output
 
 - name: Get id for client showcase-public
-  shell: oc get secret keycloak-secret-showcase-public -o jsonpath={.data.id} | base64 --decode
+  shell: oc get secret keycloak-secret-showcase-public -o jsonpath={.data.id} -n {{namespace}} | base64 --decode
   register: public_client_id_output
 
 - set_fact:

--- a/roles/setup-services/tasks/create-binding.yml
+++ b/roles/setup-services/tasks/create-binding.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Copy ServiceBinding template {{ item }}
+  template:
+    src: "{{ item }}.json.j2"
+    dest: "/tmp/{{ item }}.json"
+
+- name: Create ServiceBinding instance {{ item }}
+  shell: oc apply -f /tmp/{{ item }}.json -n {{ namespace }}

--- a/roles/setup-services/tasks/main.yml
+++ b/roles/setup-services/tasks/main.yml
@@ -1,0 +1,85 @@
+---
+
+- name: Check namespace doesn't already exist
+  shell: oc get namespace {{ namespace }}
+  register: namespace_exists
+  failed_when: namespace_exists.stderr != '' and 'NotFound' not in namespace_exists.stderr
+
+- name: Create namespace {{ namespace }} if it doesnt exist
+  shell: oc create namespace {{ namespace }}
+  when: namespace_exists.rc != 0
+
+- include_tasks: provision-service.yml
+  with_items: "{{ services }}"
+
+- name: Wait for all services to be ready
+  shell: oc get serviceinstance -o=jsonpath='{.items[*].status.conditions[0].status}' | tr ' ' '\n' | grep True | wc -w
+  register: ready_status_output
+  until: ready_status_output.stdout == "6"
+  retries: 50
+  delay: 10
+  failed_when: false
+  changed_when: false
+
+- name: Copy template for mobileclient CR
+  template:
+    src: mobileclient.json.j2
+    dest: /tmp/mobileclient.json
+
+- name: Create mobileclient
+  shell: oc apply -f /tmp/mobileclient.json -n {{ namespace }}
+
+- include_tasks: create-binding.yml
+  with_items:
+    - binding-idm-app
+    - binding-idm-showcase-server
+    - binding-metrics-app
+    - binding-sync-app
+
+- set_fact: bindings=4
+
+- name: Bind Push Android
+  block:
+    - include_tasks: create-binding.yml
+      with_items:
+        - binding-ups-app-android
+    - set_fact: bindings={{ bindings | int + 1}}
+  when: push_android_server_key != "" and push_android_sender_id != ""
+
+- name: Bind Push iOS
+  block:
+    - include_tasks: create-binding.yml
+      with_items:
+        - binding-ups-app-ios
+    - set_fact: bindings={{ bindings | int + 1}}
+  when: push_ios_cert_content != "" and push_ios_cert_passphase != "" and push_ios_cert_production != ""
+
+- name: Wait for all bindings to be completed
+  shell: oc get servicebindings -o=jsonpath='{.items[*].status.conditions[0].status}' | tr ' ' '\n' | grep True| wc -w
+  register: bindings_ready_status_output
+  until: bindings_ready_status_output.stdout == bindings|string
+  retries: 50
+  delay: 5
+  failed_when: false
+  changed_when: false
+
+- name: Patch Showcase-server
+  block:
+    - name: Copy showcase PVC template
+      template:
+        src: sync-storage.yaml.j2
+        dest: /tmp/sync-storage.yaml
+    
+    - name: Create PVC for showcase-server
+      shell: oc apply -f /tmp/sync-storage.yaml -n {{ namespace }}
+    
+    - name: Copy showcase-server patch template
+      template:
+        src: sync-patch.json.j2
+        dest: /tmp/sync-patch.json
+
+    - name: Patch deployment config for showcase-server
+      shell: oc patch dc/sync-app-showcase-server -p "$(cat /tmp/sync-patch.json)" -n {{ namespace }}
+
+- include_tasks: configure-keycloak.yml
+

--- a/roles/setup-services/tasks/main.yml
+++ b/roles/setup-services/tasks/main.yml
@@ -16,7 +16,7 @@
   shell: oc get serviceinstance -o=jsonpath='{.items[*].status.conditions[0].status}' -n {{namespace}} | tr ' ' '\n' | grep True | wc -w
   register: ready_status_output
   until: ready_status_output.stdout == "6"
-  retries: 50
+  retries: 100
   delay: 10
   failed_when: false
   changed_when: false

--- a/roles/setup-services/tasks/main.yml
+++ b/roles/setup-services/tasks/main.yml
@@ -13,7 +13,7 @@
   with_items: "{{ services }}"
 
 - name: Wait for all services to be ready
-  shell: oc get serviceinstance -o=jsonpath='{.items[*].status.conditions[0].status}' | tr ' ' '\n' | grep True | wc -w
+  shell: oc get serviceinstance -o=jsonpath='{.items[*].status.conditions[0].status}' -n {{namespace}} | tr ' ' '\n' | grep True | wc -w
   register: ready_status_output
   until: ready_status_output.stdout == "6"
   retries: 50
@@ -55,7 +55,7 @@
   when: push_ios_cert_content != "" and push_ios_cert_passphase != "" and push_ios_cert_production != ""
 
 - name: Wait for all bindings to be completed
-  shell: oc get servicebindings -o=jsonpath='{.items[*].status.conditions[0].status}' | tr ' ' '\n' | grep True| wc -w
+  shell: oc get servicebindings -o=jsonpath='{.items[*].status.conditions[0].status}' -n {{namespace}} | tr ' ' '\n' | grep True| wc -w
   register: bindings_ready_status_output
   until: bindings_ready_status_output.stdout == bindings|string
   retries: 50

--- a/roles/setup-services/tasks/provision-service.yml
+++ b/roles/setup-services/tasks/provision-service.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Copy service template file for service {{ item }}
+  template: 
+    src: "{{ item }}.json.j2"
+    dest: /tmp/{{ item }}.json
+
+- name: Provision service {{ item }}
+  shell: oc apply -f /tmp/{{ item }}.json -n {{ namespace }}
+   

--- a/roles/setup-services/templates/binding-idm-app.json.j2
+++ b/roles/setup-services/templates/binding-idm-app.json.j2
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "kind": "ServiceBinding",
+  "metadata": {
+    "name": "mobile-idm-app-binding",
+    "labels": {
+      "mobileclients.mobile.k8s.io/clientId": "{{ appname }}"
+    },
+    "annotations": {
+      "binding.aerogear.org/consumer": "{{ appname }}",
+      "binding.aerogear.org/provider": "mobile-idm-service" 
+    }
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "mobile-idm-service"
+    },
+    "parameters": {
+      "CLIENT_ID": "{{ appname }}",
+      "CLIENT_TYPE": "public"
+    }
+  }
+}

--- a/roles/setup-services/templates/binding-idm-showcase-server.json.j2
+++ b/roles/setup-services/templates/binding-idm-showcase-server.json.j2
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "kind": "ServiceBinding",
+  "metadata": {
+    "name": "mobile-idm-showcase-server-binding"
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "mobile-idm-service"
+    },
+    "parameters": {
+      "CLIENT_ID": "showcase-server",
+      "CLIENT_TYPE": "bearer"
+    }
+  }
+}

--- a/roles/setup-services/templates/binding-metrics-app.json.j2
+++ b/roles/setup-services/templates/binding-metrics-app.json.j2
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "kind": "ServiceBinding",
+  "metadata": {
+    "name": "mobile-metrics-app-binding",
+    "labels": {
+      "mobileclients.mobile.k8s.io/clientId": "{{ appname }}"
+    },
+    "annotations": {
+      "binding.aerogear.org/consumer": "{{ appname }}",
+      "binding.aerogear.org/provider": "mobile-metrics" 
+    }
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "mobile-metrics"
+    },
+    "parameters": {
+      "CLIENT_ID": "{{ appname }}"
+    }
+  }
+}

--- a/roles/setup-services/templates/binding-sync-app.json.j2
+++ b/roles/setup-services/templates/binding-sync-app.json.j2
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "kind": "ServiceBinding",
+  "metadata": {
+    "name": "mobile-sync-app-binding",
+    "labels": {
+      "mobileclients.mobile.k8s.io/clientId": "{{ appname }}"
+    },
+    "annotations": {
+      "binding.aerogear.org/consumer": "{{ appname }}",
+      "binding.aerogear.org/provider": "showcase-server" 
+    }
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "showcase-server"
+    },
+    "parameters": {
+      "CLIENT_ID": "{{ appname }}"
+    }
+  }
+}

--- a/roles/setup-services/templates/binding-ups-app-android.json.j2
+++ b/roles/setup-services/templates/binding-ups-app-android.json.j2
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "kind": "ServiceBinding",
+  "metadata": {
+    "name": "mobile-ups-app-android-binding",
+    "labels": {
+      "mobileclients.mobile.k8s.io/clientId": "{{ appname }}"
+    },
+    "annotations": {
+      "binding.aerogear.org/consumer": "{{ appname }}",
+      "binding.aerogear.org/provider": "mobile-push",
+      "mobile.aerogear.org/platform": "android" 
+    }
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "mobile-push"
+    },
+    "parameters": {
+      "CLIENT_ID": "{{ appname }}",
+      "CLIENT_TYPE": "Android",
+      "googlekey": "{{ push_android_server_key }}", 
+      "projectNumber": "{{ push_android_sender_id }}"
+    }
+  }
+}

--- a/roles/setup-services/templates/binding-ups-app-ios.json.j2
+++ b/roles/setup-services/templates/binding-ups-app-ios.json.j2
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "kind": "ServiceBinding",
+  "metadata": {
+    "name": "mobile-ups-app-ios-binding",
+    "labels": {
+      "mobileclients.mobile.k8s.io/clientId": "{{ appname }}"
+    },
+    "annotations": {
+      "binding.aerogear.org/consumer": "{{ appname }}",
+      "binding.aerogear.org/provider": "mobile-push",
+      "mobile.aerogear.org/platform": "ios"
+    }
+  },
+  "spec": {
+    "instanceRef": {
+      "name": "mobile-push"
+    },
+    "parameters": {
+      "CLIENT_ID": "{{ appname }}",
+      "CLIENT_TYPE": "IOS",
+      "cert": "{{ push_ios_cert_content }}",
+      "passphrase": "{{ push_ios_cert_passphase }}", 
+      "iosIsProduction": "{{ push_ios_cert_production | bool }}"
+    }
+  }
+}

--- a/roles/setup-services/templates/datasync.json.j2
+++ b/roles/setup-services/templates/datasync.json.j2
@@ -1,0 +1,23 @@
+{
+  "kind": "ServiceInstance",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": { "name": "showcase-server" },
+  "spec": {
+    "clusterServiceClassExternalName": "ag-sync-sync-app-apb",
+    "clusterServicePlanExternalName": "default",
+    "parameters": {
+      "SYNC_APP_NAME": "showcase-server",
+      "SYNC_APP_DOCKER_IMAGE": "docker.io/aerogear/voyager-server-example-task",
+      "SYNC_APP_DOCKER_IMAGE_VERSION": "latest",
+      "SYNC_APP_PORT": 4000,
+      "SYNC_APP_METRICS_ENDPOINT": "/metrics",
+      "SYNC_APP_GRAPHQL_ENDPOINT": "/graphql",
+      "DB_HOSTNAME": "postgresql",
+      "DB_NAME": "postgres",
+      "DB_PORT": 5432,
+      "DB_USERNAME": "postgres",
+      "DB_PASSWORD": "postgres",
+      "DB_SSL": false
+    }
+  }
+}

--- a/roles/setup-services/templates/db.json.j2
+++ b/roles/setup-services/templates/db.json.j2
@@ -1,0 +1,19 @@
+{
+  "kind": "ServiceInstance",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": { "name": "postgresql" },
+  "spec": {
+    "clusterServiceClassExternalName": "postgresql-persistent",
+    "clusterServicePlanExternalName": "default",
+    "parameters": {
+      "DATABASE_SERVICE_NAME":"postgresql",
+      "MEMORY_LIMIT":"512Mi",
+      "NAMESPACE":"openshift",
+      "POSTGRESQL_DATABASE":"postgres",
+      "POSTGRESQL_PASSWORD":"postgres",
+      "POSTGRESQL_USER":"postgres",
+      "POSTGRESQL_VERSION":"9.6",
+      "VOLUME_CAPACITY":"1Gi"
+    }
+  }
+}

--- a/roles/setup-services/templates/idm.json.j2
+++ b/roles/setup-services/templates/idm.json.j2
@@ -1,0 +1,13 @@
+{
+  "kind": "ServiceInstance",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": { "name": "mobile-idm-service" },
+  "spec": {
+    "clusterServiceClassExternalName": "ag-keycloak-identity-management-apb",
+    "clusterServicePlanExternalName": "default",
+    "parameters": {
+      "ADMIN_USERNAME": "admin",
+      "ADMIN_PASSWORD": "admin"
+    }
+  }
+}

--- a/roles/setup-services/templates/mdc.json.j2
+++ b/roles/setup-services/templates/mdc.json.j2
@@ -1,0 +1,9 @@
+{
+  "kind": "ServiceInstance",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": { "name": "mobile-developer-console" },
+  "spec": {
+    "clusterServiceClassExternalName": "ag-mdc-mdc-server-apb",
+    "clusterServicePlanExternalName": "default"
+  }
+}

--- a/roles/setup-services/templates/metrics.json.j2
+++ b/roles/setup-services/templates/metrics.json.j2
@@ -1,0 +1,14 @@
+{
+  "kind": "ServiceInstance",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": { "name": "mobile-metrics" },
+  "spec": {
+    "clusterServiceClassExternalName": "ag-metrics-metrics-apb",
+    "clusterServicePlanExternalName": "default",
+    "parameters": {
+      "GRAFANA_STORAGE_SIZE": 10,
+      "PROMETHEUS_STORAGE_SIZE": 10,
+      "POSTGRES_STORAGE_SIZE": 10
+    }
+  }
+}

--- a/roles/setup-services/templates/mobileclient.json.j2
+++ b/roles/setup-services/templates/mobileclient.json.j2
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "mobile.k8s.io/v1alpha1",
+  "kind": "MobileClient",
+  "metadata": {
+    "name": "{{ appname }}",
+    "namespace": "{{ namespace }}"
+  },
+  "spec": {
+    "name": "{{ appname }}",
+    "apiKey": "bf997a82-9415-40fc-8480-e222a97d55b4"
+  }
+}

--- a/roles/setup-services/templates/push.json.j2
+++ b/roles/setup-services/templates/push.json.j2
@@ -1,0 +1,9 @@
+{
+  "kind": "ServiceInstance",
+  "apiVersion": "servicecatalog.k8s.io/v1beta1",
+  "metadata": { "name": "mobile-push" },
+  "spec": {
+    "clusterServiceClassExternalName": "ag-push-unifiedpush-apb",
+    "clusterServicePlanExternalName": "default"
+  }
+}

--- a/roles/setup-services/templates/sync-patch.json.j2
+++ b/roles/setup-services/templates/sync-patch.json.j2
@@ -1,0 +1,33 @@
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [{
+          "name": "sync-app-showcase-server",
+          "env": [{
+            "name": "KEYCLOAK_CONFIG",
+            "value": "/tmp/keycloak-config/config"
+          }],
+          "volumeMounts": [{
+            "name": "files-storage",
+            "mountPath": "/usr/src/app/files"
+          },{
+            "name": "keycloak-config",
+            "mountPath": "/tmp/keycloak-config"
+          }]
+        }],
+        "volumes": [{
+          "name": "files-storage",
+          "persistentVolumeClaim": {
+            "claimName": "showcase-server-file-storage"
+          }
+        }, {
+          "name": "keycloak-config",
+          "secret": {
+            "secretName": "keycloak-secret-showcase-server-bearer"
+          }
+        }]
+      }
+    }
+  }
+}

--- a/roles/setup-services/templates/sync-storage.yaml.j2
+++ b/roles/setup-services/templates/sync-storage.yaml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: showcase-server-file-storage
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ showcase_server_file_storage_size }}

--- a/setup-demo.yml
+++ b/setup-demo.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Setup Mobile Services Demo
+  hosts: localhost
+  roles:
+  - role: setup-services


### PR DESCRIPTION
This will add new playbook to set up all the services for a demo.

To verify, checkout the branch and run the playbook:

```
ansible-playbook setup-demo.yml
```

It's best to run it on the bastion server of an openshift/integreatly workshop cluster, or a linux machine. macos may not work very well.