### PR TITLE
Fix oc-cluster-up.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.retry
 scripts/broker.json
+/openshift.local.clusterup

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -117,7 +117,7 @@ function clusterup() {
 if ! curl -k "https://$PUBLIC_IP.nip.io:8443" >/dev/null 2>&1; then
     clusterup
 else
-    echo "warn: skip oc cluser up because already running" >&2
+    echo "warn: skipping oc cluster up because it's already running" >&2
 fi
 
 oc login -u system:admin

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -80,7 +80,8 @@ function bootstrap() {
         --base-dir "$BASE_DIR" \
         --public-hostname="$PUBLIC_IP.nip.io" \
         --routing-suffix="$PUBLIC_IP.nip.io" \
-        --no-proxy="$PUBLIC_IP"
+        --no-proxy="$PUBLIC_IP" \
+        --enable="*,-rhel-imagestreams"
 
     # allow all origins '.*'
     for a in kube-apiserver openshift-apiserver openshift-controller-manager; do
@@ -101,7 +102,8 @@ function clusterup() {
         --base-dir "$BASE_DIR" \
         --public-hostname="$PUBLIC_IP.nip.io" \
         --routing-suffix="$PUBLIC_IP.nip.io" \
-        --no-proxy="$PUBLIC_IP"
+        --no-proxy="$PUBLIC_IP" \
+        --enable="*,-rhel-imagestreams"
 }
 
 if ! curl -k "https://$PUBLIC_IP.nip.io:8443" >/dev/null 2>&1; then

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -105,9 +105,9 @@ function clusterup() {
     if [[ "$post" == "true" ]]; then
 
         # add additional components
-        oc cluster add template-service-broker
-        oc cluster add automation-service-broker
-        oc cluster add service-catalog
+        oc cluster add --base-dir "$BASE_DIR" template-service-broker
+        oc cluster add --base-dir "$BASE_DIR" automation-service-broker
+        oc cluster add --base-dir "$BASE_DIR" service-catalog
 
         # generate self signed certificate
         ROUTING_SUFFIX="$PUBLIC_IP.nip.io" \

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -6,7 +6,7 @@ __FILENAME="$0"
 __DIRNAME="$(cd "$(dirname "$__FILENAME")" && pwd)"
 
 if [[ -L "$__FILENAME" ]]; then
-    echo "warn: because '$__FILENAME' is a symlink it could cause unxpected failurs" >&2
+    echo "warn: because '$__FILENAME' is a symlink it could cause unexpected failures" >&2
 fi
 
 function ipv4() {

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -1,29 +1,122 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "$0")"
+set -e
 
-oc cluster down
+__FILENAME="$0"
+__DIRNAME="$(cd "$(dirname "$__FILENAME")" && pwd)"
 
-if [ -z "${DEFAULT_CLUSTER_IP}" ]; then
-    export DEFAULT_CLUSTER_IP=$(ifconfig $(netstat -nr | awk '{if (($1 == "0.0.0.0" || $1 == "default") && $2 != "0.0.0.0" && $2 ~ /[0-9\.]+{4}/){print $NF;} }' | head -n1) | grep 'inet ' | awk '{print $2}')
+if [[ -L "$__FILENAME" ]]; then
+    echo "warn: because '$__FILENAME' is a symlink it could cause unxpected failurs" >&2
 fi
 
-oc cluster up \
-    --public-hostname=$DEFAULT_CLUSTER_IP.nip.io \
-    --routing-suffix=$DEFAULT_CLUSTER_IP.nip.io \
-    --no-proxy=$DEFAULT_CLUSTER_IP || exit 1
+function ipv4() {
+    ifconfig "$(
+        netstat -nr |
+            awk '{if (($1 == "0.0.0.0" || $1 == "default") && $2 != "0.0.0.0" && $2 ~ /[0-9\.]+{4}/){print $NF;} }' |
+            head -n1
+    )" |
+        grep 'inet ' |
+        awk '{print $2}'
+}
 
-oc cluster add service-catalog
-oc cluster add automation-service-broker
-oc cluster add template-service-broker
+BASE_DIR="$__DIRNAME/../openshift.local.clusterup"
+PUBLIC_IP="$(ipv4)"
+REGISTRY_USERNAME="${REGISTRY_USERNAME:-}"
+REGISTRY_PASSWORD="${REGISTRY_PASSWORD:-}"
+
+function help() {
+    echo "$__FILENAME OPTIONS"
+    echo
+    echo "Options:"
+    echo "  --base-dir                  (default: $BASE_DIR)"
+    echo "  --public-ip ipv4            (default: $PUBLIC_IP)"
+    echo "  --registry-username string  Username for registry.redhat.io (env: REGISTRY_USERNAME)"
+    echo "  --registry-password string  Password for registry.redhat.io (env: REGISTRY_PASSWORD)"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -h | --help)
+        help
+        exit 0
+        ;;
+    --base-dir)
+        BASE_DIR="$2"
+        shift
+        shift
+        ;;
+    --public-ip)
+        PUBLIC_IP="$2"
+        shift
+        shift
+        ;;
+    --registry-username)
+        REGISTRY_USERNAME="$2"
+        shift
+        shift
+        ;;
+    --registry-password)
+        REGISTRY_PASSWORD="$2"
+        shift
+        shift
+        ;;
+    *)
+        echo "error: invalid option '$1'"
+        exit 1
+        ;;
+    esac
+done
+
+if [[ -z "$REGISTRY_USERNAME" ]] || [[ -z "$REGISTRY_PASSWORD" ]]; then
+    echo "error: REGISTRY_USERNAME and/or REGISTRY_PASSWORD are not defined" >&2
+    exit 1
+fi
+
+function bootstrap() {
+
+    # only write the configuration but don't start the cluster
+    oc cluster up \
+        --write-config \
+        --base-dir "$BASE_DIR" \
+        --public-hostname="$PUBLIC_IP.nip.io" \
+        --routing-suffix="$PUBLIC_IP.nip.io" \
+        --no-proxy="$PUBLIC_IP"
+
+    # allow all origins '.*'
+    for a in kube-apiserver openshift-apiserver openshift-controller-manager; do
+        sed -i 's/^\(corsAllowedOrigins:\)$/\1\n- .*/' "$BASE_DIR/$a/master-config.yaml"
+    done
+}
+
+function clusterup() {
+
+    if [[ ! -f "$BASE_DIR/components.json" ]]; then
+        bootstrap
+    else
+        echo "warn: reuse existing configuration" >&2
+    fi
+
+    # start the cluster
+    oc cluster up \
+        --base-dir "$BASE_DIR" \
+        --public-hostname="$PUBLIC_IP.nip.io"
+}
+
+if ! curl -k "https://$PUBLIC_IP.nip.io:8443" >/dev/null 2>&1; then
+    clusterup
+else
+    echo "warn: skip oc cluser up because already running" >&2
+fi
 
 oc login -u system:admin
 
-chcon -Rt svirt_sandbox_file_t .
+# install mobile services
+ansible-playbook "$__DIRNAME/../install-mobile-services.yml" \
+    -e registry_username="$REGISTRY_USERNAME" \
+    -e registry_password="$REGISTRY_PASSWORD" \
+    -e openshift_master_url="https://$PUBLIC_IP.nip.io:8443"
 
-ansible-playbook ../install-mobile-services.yml -e registry_service_account_username=$REGISTRY_USERNAME -e registry_password=$REGISTRY_PASSWORD -e openshift_master_url="https://$(minishift ip)"
-
-export ROUTING_SUFFIX=$DEFAULT_CLUSTER_IP.nip.io
-export CONTROLLER_MANAGER_DIR="$(pwd)/openshift.local.clusterup/openshift-controller-manager"
-
-./setup-router-certs.sh
+# generate self signed certificate
+ROUTING_SUFFIX="$PUBLIC_IP.nip.io" \
+    CONTROLLER_MANAGER_DIR="$BASE_DIR/openshift-controller-manager" \
+    "$__DIRNAME/setup-router-certs.sh"

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -84,7 +84,7 @@ function clusterup() {
             --base-dir "$BASE_DIR" \
             --public-hostname "$PUBLIC_IP.nip.io" \
             --routing-suffix "$PUBLIC_IP.nip.io" \
-            --no-proxy "$PUBLIC_IP" \
+            --no-proxy "$PUBLIC_IP"
 
         # allow all origins '.*'
         for a in kube-apiserver openshift-apiserver openshift-controller-manager; do

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -104,8 +104,7 @@ function clusterup() {
         --base-dir "$BASE_DIR" \
         --public-hostname="$PUBLIC_IP.nip.io" \
         --routing-suffix="$PUBLIC_IP.nip.io" \
-        --no-proxy="$PUBLIC_IP" \
-        --enable="*,-rhel-imagestreams"
+        --no-proxy="$PUBLIC_IP"
 
     if [[ "$setupcerts" == "true" ]]; then
         # generate self signed certificate

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -96,7 +96,7 @@ function clusterup() {
         bootstrap
         setupcerts="true"
     else
-        echo "warn: reuse existing configuration" >&2
+        echo "warn: using existing configuration" >&2
     fi
 
     # start the cluster

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -99,7 +99,9 @@ function clusterup() {
     # start the cluster
     oc cluster up \
         --base-dir "$BASE_DIR" \
-        --public-hostname="$PUBLIC_IP.nip.io"
+        --public-hostname="$PUBLIC_IP.nip.io" \
+        --routing-suffix="$PUBLIC_IP.nip.io" \
+        --no-proxy="$PUBLIC_IP"
 }
 
 if ! curl -k "https://$PUBLIC_IP.nip.io:8443" >/dev/null 2>&1; then

--- a/scripts/oc-cluster-up.sh
+++ b/scripts/oc-cluster-up.sh
@@ -108,15 +108,6 @@ function clusterup() {
 
     if [[ "$post" == "true" ]]; then
 
-        # add additional components
-        for c in \
-            service-catalog \
-            template-service-broker \
-            automation-service-broker; do
-
-            oc cluster add --base-dir "$BASE_DIR" "$c"
-        done
-
         # generate self signed certificate
         ROUTING_SUFFIX="$PUBLIC_IP.nip.io" \
             CONTROLLER_MANAGER_DIR="$BASE_DIR/openshift-controller-manager" \


### PR DESCRIPTION
After the latest refactoring of the mobile-services-installer the `oc-cluster-up.sh` the script was not working. There was one issue with some variables names and a major issue with CORS.

To solve bot issues I've opted for a full refactor of the script in order to make it more understandable and configurable, but I'm also of the idea that maybe we could have reached the same result with an ansible-playbook.

**How to test:**

This should work only on Linux because the suggested way for mac is minishift, and the only requirements is oc >= 3.11

```
export REGISTRY_USERNAME=<registry_service_account_username>
export REGISTRY_PASSWORD=<registry_service_account_password>
./scripts/oc-cluster-up.sh
```